### PR TITLE
Fix(pages): enable SPA routing fallback for GitHub Pages

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -3,13 +3,13 @@ import { createBrowserRouter } from "react-router-dom";
 import HomePage from "../pages/HomePage/HomePage.tsx";
 import ReaderPage from "../pages/ReaderPage/ReaderPage.tsx";
 
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+
 export const router = createBrowserRouter(
   [
     { path: "/", element: <HomePage /> },
     { path: "/read/:translation/:book/:chapter", element: <ReaderPage /> },
   ],
-  {
-    // importante pro GitHub Pages quando deploy fica em /bible/
-    basename: import.meta.env.BASE_URL,
-  }
+  { basename: base }
 );
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,19 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { copyFileSync } from "node:fs";
+import { resolve } from "node:path";
 
-// https://vite.dev/config/
+function spaFallback404() {
+  return {
+    name: "spa-fallback-404",
+    closeBundle() {
+      const outDir = resolve(__dirname, "dist");
+      copyFileSync(resolve(outDir, "index.html"), resolve(outDir, "404.html"));
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
-  base: '/bible/',
-})
+  base: "/bible/",
+  plugins: [react(), spaFallback404()],
+});


### PR DESCRIPTION
## Context

GitHub Pages serves static files and does not support client-side routing by default.
Direct access to nested routes (e.g. `/read/pt/genesis/1`) resulted in a 404 error,
even though the application worked correctly when navigating from the home page.

This PR fixes SPA routing on GitHub Pages by adding a proper fallback mechanism.

---

## What was changed

### ✅ SPA fallback for GitHub Pages
- Added a Vite build hook to generate `404.html` from `index.html`
- Ensures all unknown routes are handled by the React application

### ✅ Router robustness
- Normalized `basename` configuration for `createBrowserRouter`
- Ensures consistent behavior between local development and GitHub Pages deployment

---

## Why this is needed

GitHub Pages attempts to resolve routes as physical files.
For SPAs using React Router with clean URLs, this causes direct access to deep links to fail.

By providing a `404.html` fallback:
- GitHub Pages loads the SPA for unknown routes
- React Router takes over and resolves the correct view

This is a standard and recommended approach for SPAs on GitHub Pages.

---

## How to test

After deployment:

- ✅ `/bible/`
- ✅ `/bible/read/pt/genesis/1`
- ✅ `/bible/read/en/matthew/1`
- ✅ `/bible/read/la/genesis/1`

All routes should load correctly, including direct access and page refresh.

---

## Scope

- No functional changes to the reader
- No UI changes
- Deployment and routing fix only
